### PR TITLE
T378 avahi mdns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+debian/files
+debian/*.debhelper.log
+debian/*.substvars
+debian/vyos-world

--- a/debian/control
+++ b/debian/control
@@ -44,6 +44,7 @@ Depends: vyatta-cfg-system,
  vyos-nhrp,
  vyos-pppoe-server,
  ubnt-igmpproxy,
- vyos-1x
+ vyos-1x,
+ vyos-cfg-avahi
 Description: VyOS metapackage
  Installs everything required for VyOS to work

--- a/debian/control
+++ b/debian/control
@@ -45,6 +45,7 @@ Depends: vyatta-cfg-system,
  vyos-pppoe-server,
  ubnt-igmpproxy,
  vyos-1x,
- vyos-cfg-avahi
+ vyos-cfg-avahi,
+ vyos-bcast-relay
 Description: VyOS metapackage
  Installs everything required for VyOS to work


### PR DESCRIPTION
This pull request was missing which blocked mdns repeater and bcast relay to be in the nightly ISO.