### PR TITLE
nhrp: T3599: Remove vyos-nhrp when migrated to vyos-1x

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,6 @@ Depends: vyatta-cfg-system,
  vyatta-conntrack,
  vyatta-wanloadbalance,
  vyatta-zone,
- vyos-nhrp,
  vyos-1x
 Description: VyOS metapackage
  Installs everything required for VyOS to work


### PR DESCRIPTION
If/when https://github.com/vyos/vyos-1x/pull/865 is merged, this dependency needs to be removed to prevent build problems.