### PR TITLE
config-mgmt: T4942: drop package vyatta-config-mgmt

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Depends: vyatta-cfg-system,
  vyatta-bash,
  vyatta-op,
  vyatta-cfg,
- vyatta-config-mgmt,
  vyatta-cluster,
  vyatta-wanloadbalance,
  vyos-1x


### PR DESCRIPTION
This PR supports:
https://github.com/vyos/vyos-1x/pull/1767
and is dependent on
https://github.com/vyos/vyatta-cfg/pull/57