### PR TITLE
T2897: remove dependency on vyos-cluster

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Depends: vyatta-cfg-system,
  vyatta-bash,
  vyatta-op,
  vyatta-cfg,
- vyatta-cluster,
  vyatta-wanloadbalance,
  vyos-1x
 Description: VyOS metapackage


### PR DESCRIPTION
It's migrated to VRRP now (https://github.com/vyos/vyos-1x/pull/2377)